### PR TITLE
Configurable licensing system

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -158,9 +158,7 @@ local function spawnPeds()
                 local zone = BoxZone:Create(current.coords.xyz, options.length, options.width, {
                     name = "zone_cityhall_"..ped,
                     heading = current.coords.w,
-                    debugPoly = false,
-                    minZ = current.coords.z - 3.0,
-                    maxZ = current.coords.z + 2.0
+                    debugPoly = false
                 })
                 zone:onPlayerInOut(function(inside)
                     if isLoggedIn and closestCityhall and closestDrivingSchool then
@@ -251,11 +249,23 @@ end)
 
 RegisterNUICallback('requestId', function(id, cb)
     local license = Config.Cityhalls[closestCityhall].licenses[id.type]
-    if inRangeCityhall and license and id.cost == license.cost then
-        TriggerServerEvent('qb-cityhall:server:requestId', id.type, closestCityhall)
-        QBCore.Functions.Notify(('You have received your %s for $%s'):format(license.label, id.cost), 'success', 3500)
+    if Config.uselicense == true then
+        if inRangeCityhall and license == 'driver' and id.cost == license.cost and SearchedPlayer.PlayerData.metadata["licences"]["driver"] == true then
+            TriggerServerEvent('qb-cityhall:server:requestId', id.type, closestCityhall)
+            QBCore.Functions.Notify(('You have received your %s for $%s'):format(license.label, id.cost), 'success', 3500)
+        elseif inRangeCityhall and license == 'id_card' and id.cost == license.cost and SearchedPlayer.PlayerData.metadata["licences"]["id_card"] == true then
+            TriggerServerEvent('qb-cityhall:server:requestId', id.type, closestCityhall)
+            QBCore.Functions.Notify(('You have received your %s for $%s'):format(license.label, id.cost), 'success', 3500)
+        else
+            QBCore.Functions.Notify('you do not have the correct license!', 'error')
+        end
     else
-        QBCore.Functions.Notify(Lang:t('error.not_in_range'), 'error')
+        if inRangeCityhall and license and id.cost == license.cost then
+            TriggerServerEvent('qb-cityhall:server:requestId', id.type, closestCityhall)
+            QBCore.Functions.Notify(('You have received your %s for $%s'):format(license.label, id.cost), 'success', 3500)
+        else
+            QBCore.Functions.Notify(Lang:t('error.not_in_range'), 'error')
+        end
     end
     cb('ok')
 end)

--- a/config.lua
+++ b/config.lua
@@ -2,6 +2,8 @@ Config = Config or {}
 
 Config.UseTarget = GetConvar('UseTarget', 'false') == 'true' -- Use qb-target interactions (don't change this, go to your server.cfg and add `setr UseTarget true` to use this and just that from true to false or the other way around)
 
+Config.uselicense = true -- use license system (true/false)
+
 Config.Cityhalls = {
     { -- Cityhall 1
         coords = vec3(-265.0, -963.6, 31.2),
@@ -19,34 +21,27 @@ Config.Cityhalls = {
                 cost = 50,
             },
             ["driver_license"] = {
-                label = "Driver License",
-                cost = 50,
-                metadata = "driver"
-            },
-            ["weaponlicense"] = {
-                label = "Weapon License",
-                cost = 50,
-                metadata = "weapon"
+                label = "Drivers License",
+                cost = 150,
             },
         }
     },
 }
+
 
 Config.DrivingSchools = {
     { -- Driving School 1
         coords = vec3(240.3, -1379.89, 33.74),
         showBlip = true,
         blipData = {
-            sprite = 225,
+            sprite = 498,
             display = 4,
             scale = 0.65,
-            colour = 3,
-            title = "Driving School"
+            colour = 0,
+            title = "DVLA"
         },
         instructors = {
-            "DJD56142",
-            "DXT09752",
-            "SRI85140",
+            "HGR30150",
         }
     },
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -110,7 +110,7 @@ RegisterNetEvent('qb-cityhall:server:getIDs', giveStarterItems)
 
 -- Commands
 
-QBCore.Commands.Add("drivinglicense", "Give a drivers license to someone", {{"id", "ID of a person"}}, true, function(source, args)
+QBCore.Commands.Add("givelicense", "Give a drivers license to someone", {{"id", "ID of a person"}}, true, function(source, args)
     local Player = QBCore.Functions.GetPlayer(source)
     local SearchedPlayer = QBCore.Functions.GetPlayer(tonumber(args[1]))
     if SearchedPlayer then


### PR DESCRIPTION
I have made the qb-cityhall licensing configurable and it allows anyone to quickly switch between the default and the managed driving school, this allows developers to quickly be able to switch and not hassle with much code apart from the true or false and also making the driving school managed engages more rp into fivem.

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? - Yes
- Does your code fit the style guidelines? - Yes
- Does your PR fit the contribution guidelines? - Yes
