### PR TITLE
Add Job Export

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -9,6 +9,15 @@ local availableJobs = {
     ["hotdog"] = "Hot Dog Stand"
 }
 
+-- Exports
+
+local function AddCityJob(jobName, label)
+    availableJobs[jobName] = label
+    return true, "success"
+end
+
+exports('AddCityJob', AddCityJob)
+
 -- Functions
 
 local function giveStarterItems()

--- a/server/main.lua
+++ b/server/main.lua
@@ -12,8 +12,12 @@ local availableJobs = {
 -- Exports
 
 local function AddCityJob(jobName, label)
-    availableJobs[jobName] = label
-    return true, "success"
+    if availableJobs[jobName] ~= nil then 
+        return false, "already added"
+    else
+        availableJobs[jobName] = label
+        return true, "success"
+    end
 end
 
 exports('AddCityJob', AddCityJob)

--- a/server/main.lua
+++ b/server/main.lua
@@ -12,7 +12,7 @@ local availableJobs = {
 -- Exports
 
 local function AddCityJob(jobName, label)
-    if availableJobs[jobName] ~= nil then 
+    if availableJobs[jobName] ~= nil then
         return false, "already added"
     else
         availableJobs[jobName] = label


### PR DESCRIPTION
this adds an export to add jobs to city hall. I found this convenient since qbcore allows for exports to import jobs. This would allow more outside resources to be easily drag and drop. This adds qb-cityhall as a dependency for anything that calls the export. There is also a check added to see if the job already exists in the table or not. I have tested this a couple times and havent found any issues with it thus far.


**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
