### PR TITLE
feat: Properly implement AddJob export

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -333,3 +333,11 @@ CreateThread(function()
         end
     end
 end)
+
+RegisterNetEvent("qb-cityhall:client:addJob", function(job, name)
+    SendNUIMessage({
+        action = 'addJob',
+        job = job,
+        name = name
+    })
+end)

--- a/html/app.js
+++ b/html/app.js
@@ -25,6 +25,11 @@ SetJobs = function(jobs) {
     })
 }
 
+AddJob = function(job, name) {
+    let html = `<div class="job-page-block" data-job="${job}"><p>${name}</p></div>`;
+    $('.job-page-blocks').append(html);
+}
+
 ResetPages = function() {
     $(".cityhall-option-blocks").show();
     $(".cityhall-identity-page").hide();
@@ -42,6 +47,9 @@ $(document).ready(function(){
                 break;
             case "setJobs":
                 SetJobs(event.data.jobs);
+                break;
+            case "addJob":
+                AddJob(event.data.job, event.data.name);
                 break;
         }
     })

--- a/server/main.lua
+++ b/server/main.lua
@@ -16,6 +16,7 @@ local function AddCityJob(jobName, label)
         return false, "already added"
     else
         availableJobs[jobName] = label
+        TriggerClientEvent("qb-cityhall:client:addJob", -1, jobName, label)
         return true, "success"
     end
 end


### PR DESCRIPTION
**Describe Pull request**
This allows the AddJob export (previously added in #77) to show on the UI as a selectable option after being added.

Usage example on server side in a new resource that is adding the job:
*Note: This will only add the job to the qb-cityhall menu. You will still need to add the job into QBShared.Jobs*
```lua
RegisterNetEvent("onResourceStart", function(resource)
   if resource == GetCurrentResourceName() then
      Wait(100)
      local job = "Construction"
      local jobName = "Construction Worker"
      exports["qb-cityhall"]:AddCityJob(job, jobName)
   end
end)
```

This can also be added to the `QBCore.Functions.AddJob` function allowing a resource to add the job to shared/jobs table and cityhall in one go, making the usage example as follows: 
```lua
RegisterNetEvent("onResourceStart", function(resource)
   if resource == GetCurrentResourceName() then
      Wait(100)
      local job = "Construction"
      local jobName = "Construction Worker"
      QBCore.Functions.AddJob(jobName, job)
   end
end)
```
See https://github.com/qbcore-framework/qb-core/pull/870

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
