### PR TITLE
fix(client): Fix ped not spawning after logout

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -196,6 +196,7 @@ local function deletePeds()
             DeletePed(current.pedHandle)
         end
     end
+    pedsSpawned = false
 end
 
 -- Events


### PR DESCRIPTION
**Describe Pull request**
This PR sets `pedSpawned = false` on player logout.

Fixes #82

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
