### PR TITLE
Move availableJobs to Config | PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,11 @@
-**Describe Pull request**
-First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
-Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.
+## Description
 
-If your PR is to fix an issue mention that issue here
+<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
 
-**Questions (please complete the following information):**
-- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
-- Does your code fit the style guidelines? [yes/no]
-- Does your PR fit the contribution guidelines? [yes/no]
+## Checklist
+
+<!-- Put an x inside the [ ] to check an item, like so: [x] -->
+
+-   [ ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
+-   [ ] My code fits the style guidelines.
+-   [ ] My PR fits the contribution guidelines.

--- a/client/main.lua
+++ b/client/main.lua
@@ -93,7 +93,7 @@ local function initBlips()
     for i = 1, #Config.Cityhalls do
         local hall = Config.Cityhalls[i]
         if hall.showBlip then
-            blips[#blips+1] = createBlip({
+            blips[#blips + 1] = createBlip({
                 coords = hall.coords,
                 sprite = hall.blipData.sprite,
                 display = hall.blipData.display,
@@ -107,7 +107,7 @@ local function initBlips()
     for i = 1, #Config.DrivingSchools do
         local school = Config.DrivingSchools[i]
         if school.showBlip then
-            blips[#blips+1] = createBlip({
+            blips[#blips + 1] = createBlip({
                 coords = school.coords,
                 sprite = school.blipData.sprite,
                 display = school.blipData.display,
@@ -157,7 +157,7 @@ local function spawnPeds()
             end
             if opts then
                 exports['qb-target']:AddTargetEntity(ped, {
-                    options = {opts},
+                    options = { opts },
                     distance = 2.0
                 })
             end
@@ -165,7 +165,7 @@ local function spawnPeds()
             local options = current.zoneOptions
             if options then
                 local zone = BoxZone:Create(current.coords.xyz, options.length, options.width, {
-                    name = "zone_cityhall_"..ped,
+                    name = "zone_cityhall_" .. ped,
                     heading = current.coords.w,
                     debugPoly = false,
                     minZ = current.coords.z - 3.0,
@@ -243,7 +243,7 @@ RegisterNetEvent('qb-cityhall:client:sendDriverEmail', function(charinfo)
         TriggerServerEvent('qb-phone:server:sendNewMail', {
             sender = Lang:t('email.sender'),
             subject = Lang:t('email.subject'),
-            message =  Lang:t('email.message', {gender = gender, lastname = charinfo.lastname, firstname = charinfo.firstname, phone = charinfo.phone}),
+            message = Lang:t('email.message', { gender = gender, lastname = charinfo.lastname, firstname = charinfo.firstname, phone = charinfo.phone }),
             button = {}
         })
     end)

--- a/config.lua
+++ b/config.lua
@@ -3,13 +3,13 @@ Config = Config or {}
 Config.UseTarget = GetConvar('UseTarget', 'false') == 'true' -- Use qb-target interactions (don't change this, go to your server.cfg and add `setr UseTarget true` to use this and just that from true to false or the other way around)
 
 Config.AvailableJobs = { -- Only used when not using qb-jobs.
-    ["trucker"] = "Trucker",
-    ["taxi"] = "Taxi",
-    ["tow"] = "Tow Truck",
-    ["reporter"] = "News Reporter",
-    ["garbage"] = "Garbage Collector",
-    ["bus"] = "Bus Driver",
-    ["hotdog"] = "Hot Dog Stand"
+    ["trucker"] = {["label"] = "Trucker", ["isManaged"] = false},
+    ["taxi"] = {["label"] = "Taxi", ["isManaged"] = false},
+    ["tow"] = {["label"] = "Tow Truck", ["isManaged"] = false},
+    ["reporter"] = {["label"] = "News Reporter", ["isManaged"] = false},
+    ["garbage"] = {["label"] = "Garbage Collector", ["isManaged"] = false},
+    ["bus"] = {["label"] = "Bus Driver", ["isManaged"] = false},
+    ["hotdog"] = {["label"] = "Hot Dog Stand", ["isManaged"] = false}
 }
 
 Config.Cityhalls = {

--- a/config.lua
+++ b/config.lua
@@ -2,7 +2,7 @@ Config = Config or {}
 
 Config.UseTarget = GetConvar('UseTarget', 'false') == 'true' -- Use qb-target interactions (don't change this, go to your server.cfg and add `setr UseTarget true` to use this and just that from true to false or the other way around)
 
-Config.AvailableJobs = {
+Config.AvailableJobs = { -- Only used when not using qb-jobs.
     ["trucker"] = "Trucker",
     ["taxi"] = "Taxi",
     ["tow"] = "Tow Truck",

--- a/config.lua
+++ b/config.lua
@@ -2,6 +2,16 @@ Config = Config or {}
 
 Config.UseTarget = GetConvar('UseTarget', 'false') == 'true' -- Use qb-target interactions (don't change this, go to your server.cfg and add `setr UseTarget true` to use this and just that from true to false or the other way around)
 
+Config.AvailableJobs = {
+    ["trucker"] = "Trucker",
+    ["taxi"] = "Taxi",
+    ["tow"] = "Tow Truck",
+    ["reporter"] = "News Reporter",
+    ["garbage"] = "Garbage Collector",
+    ["bus"] = "Bus Driver",
+    ["hotdog"] = "Hot Dog Stand"
+}
+
 Config.Cityhalls = {
     { -- Cityhall 1
         coords = vec3(-265.0, -963.6, 31.2),

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'QB-CityHall'
-version '2.1.1'
+version '2.1.2'
 
 ui_page 'html/index.html'
 

--- a/locales/pt.lua
+++ b/locales/pt.lua
@@ -1,0 +1,30 @@
+local Translations = {
+    error = {
+        not_in_range = 'Encontra-se muito longe da camara municipal'
+    },
+    success = {
+        recived_license = 'Recebeu  %{value} por €50'
+    },
+    info = {
+        bilp_text = 'Camâra Municipal',
+        city_services_menu = 'E - Menu Serviços',
+        id_card = 'Cartão do Cidadão',
+        driver_license = 'Carta de Condução',
+        weaponlicense = 'Licença porte de arma',
+        new_job = 'Parabéns! O seu novo trabalho: (%{job})'
+    },
+    email = {
+        mr = 'Sr',
+        mrs = 'Sra',
+        sender = 'Serviços Municipais',
+        subject = 'Solicitação de aulas de condução',
+        message = 'Olá %{gender} %{lastname}<br /><br />Acabamos de receber uma mensagem de que alguém quer fazer aulas de condução<br />Se quiser fazer de instructor por favor contacte-nos:<br />Nome: <strong>%{firstname} %{lastname}</strong><br />Telemóvel: <strong>%{phone}</strong><br/><br/>Melhores Cumprimentos,<br />Serviços Municipais'
+    }
+}
+if GetConvar('qb_locale', 'en') == 'pt' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end

--- a/server/main.lua
+++ b/server/main.lua
@@ -93,7 +93,7 @@ RegisterNetEvent('qb-cityhall:server:sendDriverTest', function(instructors)
             local mailData = {
                 sender = "Township",
                 subject = "Driving lessons request",
-                message = "Hello,<br><br>We have just received a message that someone wants to take driving lessons.<br>If you are willing to teach, please contact them:<br>Name: <strong>".. Player.PlayerData.charinfo.firstname .. " " .. Player.PlayerData.charinfo.lastname .. "<br />Phone Number: <strong>"..Player.PlayerData.charinfo.phone.."</strong><br><br>Kind regards,<br>Township Los Santos",
+                message = "Hello,<br><br>We have just received a message that someone wants to take driving lessons.<br>If you are willing to teach, please contact them:<br>Name: <strong>" .. Player.PlayerData.charinfo.firstname .. " " .. Player.PlayerData.charinfo.lastname .. "<br />Phone Number: <strong>" .. Player.PlayerData.charinfo.phone .. "</strong><br><br>Kind regards,<br>Township Los Santos",
                 button = {}
             }
             exports["qb-phone"]:sendNewMailToOffline(citizenid, mailData)
@@ -116,23 +116,24 @@ RegisterNetEvent('qb-cityhall:server:ApplyJob', function(job, cityhallCoords)
     if #(pedCoords - cityhallCoords) >= 20.0 or not availableJobs[job] then
         return false -- DropPlayer(source, "Attempted exploit abuse")
     end
-    if QBCore.Shared.QBJobsStatus then exports["qb-jobs"]:submitApplication(data,"Jobs")
+    if QBCore.Shared.QBJobsStatus then
+        exports["qb-jobs"]:submitApplication(data, "Jobs")
     else
         local JobInfo = QBCore.Shared.Jobs[job]
         Player.Functions.SetJob(data.job, 0)
-        TriggerClientEvent('QBCore:Notify', data.src, Lang:t('info.new_job', {job = JobInfo.label}))
+        TriggerClientEvent('QBCore:Notify', data.src, Lang:t('info.new_job', { job = JobInfo.label }))
     end
 end)
 
 RegisterNetEvent('qb-cityhall:server:getIDs', giveStarterItems)
 
 RegisterNetEvent('QBCore:Client:UpdateObject', function()
-	QBCore = exports['qb-core']:GetCoreObject()
+    QBCore = exports['qb-core']:GetCoreObject()
 end)
 
 -- Commands
 
-QBCore.Commands.Add("drivinglicense", "Give a drivers license to someone", {{"id", "ID of a person"}}, true, function(source, args)
+QBCore.Commands.Add("drivinglicense", "Give a drivers license to someone", { { "id", "ID of a person" } }, true, function(source, args)
     local Player = QBCore.Functions.GetPlayer(source)
     local SearchedPlayer = QBCore.Functions.GetPlayer(tonumber(args[1]))
     if SearchedPlayer then

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,21 +1,12 @@
 local QBCore = exports['qb-core']:GetCoreObject()
-local availableJobs = {
-    ["trucker"] = "Trucker",
-    ["taxi"] = "Taxi",
-    ["tow"] = "Tow Truck",
-    ["reporter"] = "News Reporter",
-    ["garbage"] = "Garbage Collector",
-    ["bus"] = "Bus Driver",
-    ["hotdog"] = "Hot Dog Stand"
-}
 
 -- Exports
 
 local function AddCityJob(jobName, label)
-    if availableJobs[jobName] ~= nil then
+    if Config.AvailableJobs[jobName] ~= nil then
         return false, "already added"
     else
-        availableJobs[jobName] = label
+        Config.AvailableJobs[jobName] = label
         return true, "success"
     end
 end
@@ -49,7 +40,7 @@ end
 -- Callbacks
 
 QBCore.Functions.CreateCallback('qb-cityhall:server:receiveJobs', function(_, cb)
-    cb(availableJobs)
+    cb(Config.AvailableJobs)
 end)
 
 -- Events
@@ -113,7 +104,7 @@ RegisterNetEvent('qb-cityhall:server:ApplyJob', function(job, cityhallCoords)
     local ped = GetPlayerPed(src)
     local pedCoords = GetEntityCoords(ped)
     local JobInfo = QBCore.Shared.Jobs[job]
-    if #(pedCoords - cityhallCoords) >= 20.0 or not availableJobs[job] then
+    if #(pedCoords - cityhallCoords) >= 20.0 or not Config.AvailableJobs[job] then
         return DropPlayer(source, "Attempted exploit abuse")
     end
     Player.Functions.SetJob(job, 0)

--- a/server/main.lua
+++ b/server/main.lua
@@ -45,7 +45,7 @@ end
 -- Callbacks
 
 QBCore.Functions.CreateCallback('qb-cityhall:server:receiveJobs', function(_, cb)
-    cb(Config.AvailableJobs)
+    cb(availableJobs)
 end)
 
 -- Events


### PR DESCRIPTION
## Description

1. Moves jobs available in city hall menu to config to make it easier for newbies to find.
1.5 (I am the professional config maker)
2. Updates PR template.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

-   [ ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
(no, fivem is down 🤪)
-   [x] My code fits the style guidelines.
-   [x] My PR fits the contribution guidelines.